### PR TITLE
Add the use of java assertations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ shadowJar {
     archiveClassifier = null
 }
 
-run{
+run {
     standardInput = System.in
     enableAssertions = true
 }

--- a/src/main/java/duke/tasklist/TaskList.java
+++ b/src/main/java/duke/tasklist/TaskList.java
@@ -31,6 +31,7 @@ public class TaskList {
         ArrayList<Task> matchingTasks = new ArrayList<>();
         for (int i = 0; i < this.tasks.size(); i++) {
             Task task = tasks.get(i);
+            assert task != null : "Task is null";
             if (task.provideDetails().contains(searchWord)) {
                 matchingTasks.add(task);
             }


### PR DESCRIPTION
There are key junctures in our code that are likely to throw a critical error.

Using java assertations helps us to catch these critical faults early.

Let's add java assertations in our code.